### PR TITLE
fix: correct chess win/loss when player is black

### DIFF
--- a/src/app/chess/page.tsx
+++ b/src/app/chess/page.tsx
@@ -18,17 +18,15 @@ export default function ChessPage() {
   useEffect(() => {
     if (gameState.isGameOver && gameState.winner !== null) {
       const gameId = `${gameState.fen}-${gameState.winner}`;
-      
-      // Only process if we haven't already processed this game end
+
       if (gameEndProcessedRef.current !== gameId) {
         gameEndProcessedRef.current = gameId;
-        
-        if (gameState.winner === 'white') {
-          updateScores('win');
-        } else if (gameState.winner === 'black') {
-          updateScores('loss');
-        } else {
+
+        if (gameState.winner === 'draw') {
           updateScores('draw');
+        } else {
+          const playerWon = (gameState.winner === 'white' && playerIsWhite) || (gameState.winner === 'black' && !playerIsWhite);
+            updateScores(playerWon ? 'win' : 'loss');
         }
       }
     }
@@ -37,7 +35,7 @@ export default function ChessPage() {
     if (!gameState.isGameOver) {
       gameEndProcessedRef.current = null;
     }
-  }, [gameState.isGameOver, gameState.winner, gameState.fen, updateScores]);
+  }, [gameState.isGameOver, gameState.winner, gameState.fen, updateScores, playerIsWhite]);
 
   // Board orientation is fixed for the game, based on who started
   const boardOrientation = playerIsWhite ? 'white' : 'black';
@@ -78,6 +76,7 @@ export default function ChessPage() {
             gameState={gameState}
             onResetGame={resetGame}
             apiError={apiError}
+            playerIsWhite={playerIsWhite}
           />
           
           <ScoreBoard

--- a/src/app/chess/page.tsx
+++ b/src/app/chess/page.tsx
@@ -18,15 +18,22 @@ export default function ChessPage() {
   useEffect(() => {
     if (gameState.isGameOver && gameState.winner !== null) {
       const gameId = `${gameState.fen}-${gameState.winner}`;
-
+      
+      // Only process if we haven't already processed this game end
       if (gameEndProcessedRef.current !== gameId) {
         gameEndProcessedRef.current = gameId;
-
+        
+        // Determine if the player won based on their color and the winner
         if (gameState.winner === 'draw') {
           updateScores('draw');
         } else {
-          const playerWon = (gameState.winner === 'white' && playerIsWhite) || (gameState.winner === 'black' && !playerIsWhite);
-            updateScores(playerWon ? 'win' : 'loss');
+          const playerWon = (playerIsWhite && gameState.winner === 'white') || 
+                           (!playerIsWhite && gameState.winner === 'black');
+          if (playerWon) {
+            updateScores('win');
+          } else {
+            updateScores('loss');
+          }
         }
       }
     }
@@ -35,7 +42,7 @@ export default function ChessPage() {
     if (!gameState.isGameOver) {
       gameEndProcessedRef.current = null;
     }
-  }, [gameState.isGameOver, gameState.winner, gameState.fen, updateScores, playerIsWhite]);
+  }, [gameState.isGameOver, gameState.winner, gameState.fen, updateScores]);
 
   // Board orientation is fixed for the game, based on who started
   const boardOrientation = playerIsWhite ? 'white' : 'black';
@@ -76,7 +83,6 @@ export default function ChessPage() {
             gameState={gameState}
             onResetGame={resetGame}
             apiError={apiError}
-            playerIsWhite={playerIsWhite}
           />
           
           <ScoreBoard

--- a/src/components/chess/ChessBoard.tsx
+++ b/src/components/chess/ChessBoard.tsx
@@ -21,10 +21,8 @@ export default function ChessBoard({ gameState, onMove, boardSize, boardOrientat
       return false;
     }
     // Only allow moves for correct color
-    if ((boardOrientation === 'white' && !gameState.isPlayerTurn) ||
-        (boardOrientation === 'black' && gameState.isPlayerTurn)) {
-      return false;
-    }
+  // isPlayerTurn already encodes if human can move (perspective aware)
+  if (!gameState.isPlayerTurn) return false;
     // Execute the move asynchronously but return true for UI responsiveness
     onMove(sourceSquare, targetSquare).then(result => {
       // The result will be handled by the chess game hook
@@ -54,10 +52,7 @@ export default function ChessBoard({ gameState, onMove, boardSize, boardOrientat
     onPieceDrop: handlePieceDrop,
     boardOrientation: boardOrientation || "white",
     squareStyles: getCustomSquareStyles(),
-    allowDragging:
-      ((boardOrientation === 'white' && gameState.isPlayerTurn) ||
-       (boardOrientation === 'black' && !gameState.isPlayerTurn)) &&
-      !gameState.isGameOver && !gameState.isThinking,
+  allowDragging: gameState.isPlayerTurn && !gameState.isGameOver && !gameState.isThinking,
     orientation: boardOrientation || "white",
     boardStyle: {
       borderRadius: '4px',

--- a/src/components/chess/ChessBoard.tsx
+++ b/src/components/chess/ChessBoard.tsx
@@ -21,8 +21,10 @@ export default function ChessBoard({ gameState, onMove, boardSize, boardOrientat
       return false;
     }
     // Only allow moves for correct color
-  // isPlayerTurn already encodes if human can move (perspective aware)
-  if (!gameState.isPlayerTurn) return false;
+    if ((boardOrientation === 'white' && !gameState.isPlayerTurn) ||
+        (boardOrientation === 'black' && gameState.isPlayerTurn)) {
+      return false;
+    }
     // Execute the move asynchronously but return true for UI responsiveness
     onMove(sourceSquare, targetSquare).then(result => {
       // The result will be handled by the chess game hook
@@ -52,7 +54,10 @@ export default function ChessBoard({ gameState, onMove, boardSize, boardOrientat
     onPieceDrop: handlePieceDrop,
     boardOrientation: boardOrientation || "white",
     squareStyles: getCustomSquareStyles(),
-  allowDragging: gameState.isPlayerTurn && !gameState.isGameOver && !gameState.isThinking,
+    allowDragging:
+      ((boardOrientation === 'white' && gameState.isPlayerTurn) ||
+       (boardOrientation === 'black' && !gameState.isPlayerTurn)) &&
+      !gameState.isGameOver && !gameState.isThinking,
     orientation: boardOrientation || "white",
     boardStyle: {
       borderRadius: '4px',

--- a/src/components/chess/ChessBoard.tsx
+++ b/src/components/chess/ChessBoard.tsx
@@ -20,11 +20,12 @@ export default function ChessBoard({ gameState, onMove, boardSize, boardOrientat
     if (gameState.isGameOver || gameState.isThinking || !targetSquare) {
       return false;
     }
-    // Only allow moves for correct color
-    if ((boardOrientation === 'white' && !gameState.isPlayerTurn) ||
-        (boardOrientation === 'black' && gameState.isPlayerTurn)) {
+    
+    // Only allow moves when it's the player's turn
+    if (!gameState.isPlayerTurn) {
       return false;
     }
+    
     // Execute the move asynchronously but return true for UI responsiveness
     onMove(sourceSquare, targetSquare).then(result => {
       // The result will be handled by the chess game hook
@@ -55,8 +56,7 @@ export default function ChessBoard({ gameState, onMove, boardSize, boardOrientat
     boardOrientation: boardOrientation || "white",
     squareStyles: getCustomSquareStyles(),
     allowDragging:
-      ((boardOrientation === 'white' && gameState.isPlayerTurn) ||
-       (boardOrientation === 'black' && !gameState.isPlayerTurn)) &&
+      gameState.isPlayerTurn &&
       !gameState.isGameOver && !gameState.isThinking,
     orientation: boardOrientation || "white",
     boardStyle: {

--- a/src/components/chess/GameStatus.tsx
+++ b/src/components/chess/GameStatus.tsx
@@ -6,11 +6,9 @@ interface GameStatusProps {
   gameState: ChessGameState;
   onResetGame: () => void;
   apiError: string | null;
-  // Needed to determine perspective when showing winner colors/icons
-  playerIsWhite: boolean;
 }
 
-export default function GameStatus({ gameState, onResetGame, apiError, playerIsWhite }: GameStatusProps) {
+export default function GameStatus({ gameState, onResetGame, apiError }: GameStatusProps) {
   const handleResign = () => {
     if (window.confirm('Are you sure you want to resign? You will lose this game.')) {
       if (typeof window !== 'undefined' && window.localStorage) {
@@ -27,9 +25,9 @@ export default function GameStatus({ gameState, onResetGame, apiError, playerIsW
   };
   const getStatusColor = () => {
     if (gameState.isGameOver) {
-      if (gameState.winner === 'draw') return 'text-accent';
-      const playerWon = (gameState.winner === 'white' && playerIsWhite) || (gameState.winner === 'black' && !playerIsWhite);
-      return playerWon ? 'text-accent2' : 'text-red-400';
+      if (gameState.winner === 'white') return 'text-accent2';
+      if (gameState.winner === 'black') return 'text-red-400';
+      return 'text-accent';
     }
     return gameState.isThinking ? 'text-accent' : 'text-text';
   };
@@ -44,9 +42,9 @@ export default function GameStatus({ gameState, onResetGame, apiError, playerIsW
     }
     
     if (gameState.isGameOver) {
-      if (gameState.winner === 'draw') return ' 🤝';
-      const playerWon = (gameState.winner === 'white' && playerIsWhite) || (gameState.winner === 'black' && !playerIsWhite);
-      return playerWon ? ' 🎉' : ' 😔';
+      if (gameState.winner === 'white') return ' 🎉';
+      if (gameState.winner === 'black') return ' 😔';
+      return ' 🤝';
     }
     
     return gameState.isPlayerTurn ? ' ♔' : ' ♛';

--- a/src/components/chess/GameStatus.tsx
+++ b/src/components/chess/GameStatus.tsx
@@ -6,9 +6,11 @@ interface GameStatusProps {
   gameState: ChessGameState;
   onResetGame: () => void;
   apiError: string | null;
+  // Needed to determine perspective when showing winner colors/icons
+  playerIsWhite: boolean;
 }
 
-export default function GameStatus({ gameState, onResetGame, apiError }: GameStatusProps) {
+export default function GameStatus({ gameState, onResetGame, apiError, playerIsWhite }: GameStatusProps) {
   const handleResign = () => {
     if (window.confirm('Are you sure you want to resign? You will lose this game.')) {
       if (typeof window !== 'undefined' && window.localStorage) {
@@ -25,9 +27,9 @@ export default function GameStatus({ gameState, onResetGame, apiError }: GameSta
   };
   const getStatusColor = () => {
     if (gameState.isGameOver) {
-      if (gameState.winner === 'white') return 'text-accent2';
-      if (gameState.winner === 'black') return 'text-red-400';
-      return 'text-accent';
+      if (gameState.winner === 'draw') return 'text-accent';
+      const playerWon = (gameState.winner === 'white' && playerIsWhite) || (gameState.winner === 'black' && !playerIsWhite);
+      return playerWon ? 'text-accent2' : 'text-red-400';
     }
     return gameState.isThinking ? 'text-accent' : 'text-text';
   };
@@ -42,9 +44,9 @@ export default function GameStatus({ gameState, onResetGame, apiError }: GameSta
     }
     
     if (gameState.isGameOver) {
-      if (gameState.winner === 'white') return ' 🎉';
-      if (gameState.winner === 'black') return ' 😔';
-      return ' 🤝';
+      if (gameState.winner === 'draw') return ' 🤝';
+      const playerWon = (gameState.winner === 'white' && playerIsWhite) || (gameState.winner === 'black' && !playerIsWhite);
+      return playerWon ? ' 🎉' : ' 😔';
     }
     
     return gameState.isPlayerTurn ? ' ♔' : ' ♛';


### PR DESCRIPTION
Fixes incorrect result display and scoring when the human plays Black and loses.\n\nChanges:\n- Perspective-aware turn & winner handling in useChessGame\n- Updated board drag logic\n- GameStatus now uses player perspective\n- Correct score updates for black player outcomes\n\nTested with production build (pnpm build).